### PR TITLE
To origin grammar

### DIFF
--- a/milan-interpreter/src/it/it-interpreter/src/test/resources/program.mil
+++ b/milan-interpreter/src/it/it-interpreter/src/test/resources/program.mil
@@ -4,14 +4,13 @@ BEGIN
         b1 := (a1 / 2) * 2;
         OUTPUT(b1);
         IF a1 == 9 THEN
-            // спуск
             WHILE b1 <> 1 DO
                 OUTPUT(b1);
                 b1 := b1 - 1;
-            ENDDO
-        ENDIF
-        a1++;
-    ENDDO
+            ENDDO;
+        ENDIF;
+        a1 := a1 + 1;
+    ENDDO;
     OUTPUT(a1);
     OUTPUT(b1);
     c101 := (a1 - 30) * (b1 + 2);

--- a/milan-interpreter/src/main/antlr4/ru/milan/interpreter/Program.g4
+++ b/milan-interpreter/src/main/antlr4/ru/milan/interpreter/Program.g4
@@ -4,28 +4,23 @@ prog: BEGIN block END;
 
 block: stmt*;
 
-stmt: assignStmt | readStmt | whileStmt | ifStmt | outputStmt | incrStmt;
+stmt: assignStmt | whileStmt | ifStmt | outputStmt;
 
 assignStmt: ID ASSIGN expressions SEMICOLON;
 
 outputStmt: OUTPUT LBRACKET expressions RBRACKET SEMICOLON ;
 
-readStmt: READ LBRACKET ID RBRACKET SEMICOLON;
+whileStmt: WHILE expressions DO block ENDDO SEMICOLON;
 
-whileStmt: WHILE expressions DO block ENDDO;
-
-ifStmt: IF expressions THEN block (elseStmt)? ENDIF;
+ifStmt: IF expressions THEN block (elseStmt)? ENDIF SEMICOLON;
 
 elseStmt: ELSE block;
 
-incrStmt: ID INCR SEMICOLON
-        | INCR ID SEMICOLON
-        ;
-
 expressions: expr;
 
-expr: ID # Id
-    | INT # Int
+expr: ID                     # Id
+    | INT                    # Int
+    | READ                   # Read
     | expr MUL expr          # Multiplication
     | expr DIV expr          # Division
     | expr ADD expr          # Addition
@@ -55,8 +50,6 @@ ASSIGN: ':=';
 SEMICOLON: ';';
 LBRACKET: '(';
 RBRACKET: ')';
-INCR: '++';
-COMMENT: '//' .*? '\r'? '\n' -> skip;
 
 LTE: '<=';
 GTE: '>=';

--- a/milan-interpreter/src/main/antlr4/ru/milan/interpreter/Program.g4
+++ b/milan-interpreter/src/main/antlr4/ru/milan/interpreter/Program.g4
@@ -65,8 +65,5 @@ MUL: '*';
 
 INT: [0-9]+;
 ID: [a-zA-Z0-9]+;
-BOOL: 'true'
-    | 'false'
-    ;
 
 WS: [ \t\r\n]+ -> skip;

--- a/milan-interpreter/src/main/java/ru/milan/interpreter/ErrorListener.java
+++ b/milan-interpreter/src/main/java/ru/milan/interpreter/ErrorListener.java
@@ -1,10 +1,12 @@
 package ru.milan.interpreter;
 
+import java.util.InputMismatchException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.antlr.v4.runtime.BaseErrorListener;
 import org.antlr.v4.runtime.RecognitionException;
 import org.antlr.v4.runtime.Recognizer;
+import org.antlr.v4.runtime.misc.ParseCancellationException;
 import org.cactoos.Text;
 
 @RequiredArgsConstructor
@@ -21,14 +23,12 @@ public final class ErrorListener extends BaseErrorListener {
         final String msg,
         final RecognitionException error
     ) {
-        throw new ParsingException(
-            String.format(
-                "[%d:%d] %s: \"%s\"",
-                line, position, msg,
-                this.lines.size() < line ? "EOF" : this.lines.get(line - 1)
-            ),
-            error,
-            line
+        throw new InputMismatchException(
+            "[%d:%d] %s: \"%s\""
+                .formatted(
+                    line, position, msg,
+                    this.lines.size() < line ? "EOF" : this.lines.get(line - 1)
+                )
         );
     }
 

--- a/milan-interpreter/src/main/java/ru/milan/interpreter/MilanErrorListener.java
+++ b/milan-interpreter/src/main/java/ru/milan/interpreter/MilanErrorListener.java
@@ -1,16 +1,19 @@
 package ru.milan.interpreter;
 
+import java.util.BitSet;
 import java.util.InputMismatchException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.antlr.v4.runtime.BaseErrorListener;
+import org.antlr.v4.runtime.Parser;
 import org.antlr.v4.runtime.RecognitionException;
 import org.antlr.v4.runtime.Recognizer;
-import org.antlr.v4.runtime.misc.ParseCancellationException;
+import org.antlr.v4.runtime.atn.ATNConfigSet;
+import org.antlr.v4.runtime.dfa.DFA;
 import org.cactoos.Text;
 
 @RequiredArgsConstructor
-public final class ErrorListener extends BaseErrorListener {
+public final class MilanErrorListener extends BaseErrorListener {
 
     private final List<Text> lines;
 
@@ -31,5 +34,4 @@ public final class ErrorListener extends BaseErrorListener {
                 )
         );
     }
-
 }

--- a/milan-interpreter/src/main/java/ru/milan/interpreter/MilanInterpreter.java
+++ b/milan-interpreter/src/main/java/ru/milan/interpreter/MilanInterpreter.java
@@ -4,16 +4,13 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
 import java.util.List;
-import org.antlr.v4.runtime.ANTLRErrorListener;
-import org.antlr.v4.runtime.BailErrorStrategy;
-import org.antlr.v4.runtime.CommonTokenStream;
-import org.antlr.v4.runtime.InputMismatchException;
+
+import org.antlr.v4.runtime.*;
 import org.antlr.v4.runtime.misc.ParseCancellationException;
 import org.antlr.v4.runtime.tree.ParseTreeVisitor;
 import org.cactoos.Input;
 import org.cactoos.Text;
 import org.cactoos.list.ListOf;
-import org.cactoos.text.FormattedText;
 import org.cactoos.text.Joined;
 import org.cactoos.text.Split;
 import org.cactoos.text.TextOf;
@@ -51,7 +48,7 @@ public final class MilanInterpreter {
      */
     public void run() throws IOException {
         final List<Text> lines = this.lines();
-        final ANTLRErrorListener errors = new ErrorListener(lines);
+        final ANTLRErrorListener errors = new MilanErrorListener(lines);
         final ProgramLexer lexer = new MilanLexer(this.unixize());
         lexer.removeErrorListeners();
         lexer.addErrorListener(errors);
@@ -106,13 +103,15 @@ public final class MilanInterpreter {
     private void formatIfParseCancelled(
         final ParseCancellationException ex
     ) {
+        System.out.println(ex.getMessage());
         if (ex.getCause() instanceof InputMismatchException cause) {
+            final Token off = cause.getOffendingToken();
             this.stderr.println(
                 new FormattedErrorMessage(
-                    cause.getOffendingToken().getLine(),
-                    cause.getOffendingToken().getCharPositionInLine(),
+                    off.getLine(),
+                    off.getCharPositionInLine(),
                     "Syntax error: %s not expected"
-                        .formatted(cause.getOffendingToken().getText())
+                        .formatted(off.getText())
                 ).asString()
             );
         }

--- a/milan-interpreter/src/main/java/ru/milan/interpreter/MilanInterpreter.java
+++ b/milan-interpreter/src/main/java/ru/milan/interpreter/MilanInterpreter.java
@@ -111,7 +111,8 @@ public final class MilanInterpreter {
                 new FormattedErrorMessage(
                     cause.getOffendingToken().getLine(),
                     cause.getOffendingToken().getCharPositionInLine(),
-                    "Syntax error: " + cause.getMessage()
+                    "Syntax error: %s not expected"
+                        .formatted(cause.getOffendingToken().getText())
                 ).asString()
             );
         }

--- a/milan-interpreter/src/main/java/ru/milan/interpreter/MilanVisitor.java
+++ b/milan-interpreter/src/main/java/ru/milan/interpreter/MilanVisitor.java
@@ -5,6 +5,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.PrintStream;
+import java.util.Scanner;
+
 import org.cactoos.text.FormattedText;
 import ru.milan.interpreter.exception.InterpretationException;
 import ru.milan.interpreter.exception.WrongTypeException;
@@ -164,11 +166,10 @@ public final class MilanVisitor extends ProgramBaseVisitor<Atom> {
     }
 
     @Override
-    public Atom visitIncrStmt(final ProgramParser.IncrStmtContext ctx) {
-        final String name = ctx.ID().getText();
-        final Atom increment = this.memory.get(name).add(new Value(1));
-        this.memory.assign(name, increment);
-        return increment;
+    public Atom visitRead(final ProgramParser.ReadContext ctx) {
+        try (final Scanner scan = new Scanner(System.in)) {
+            return new Value(scan.nextInt());
+        }
     }
 
     @Override
@@ -269,28 +270,6 @@ public final class MilanVisitor extends ProgramBaseVisitor<Atom> {
         final Atom value = this.visit(ctx.expressions());
         this.print.println(value.asInteger());
         return value;
-    }
-
-    @Override
-    public Atom visitReadStmt(final ProgramParser.ReadStmtContext ctx) {
-        final String name = ctx.ID().getText();
-        try {
-            final String line = this.input.readLine();
-            final Atom value = new Value(Integer.valueOf(line));
-            this.memory.assign(name, value);
-            return value;
-        } catch (final NumberFormatException ex) {
-            throw new WrongTypeException(
-                new FormattedErrorMessage(
-                    ctx.getStart().getLine(),
-                    ctx.getStart().getCharPositionInLine(),
-                    String.format("Atom {%s} isn't integer", name)
-                ).asString(),
-                ex
-            );
-        } catch (final IOException ex) {
-            throw new IllegalStateException(ex);
-        }
     }
 
     @Override

--- a/milan-interpreter/src/main/java/ru/milan/interpreter/message/FormattedErrorMessage.java
+++ b/milan-interpreter/src/main/java/ru/milan/interpreter/message/FormattedErrorMessage.java
@@ -16,7 +16,7 @@ public final class FormattedErrorMessage implements Text {
 
     @Override
     public String asString() {
-        return "Error at [%d, %d]: %s\n".formatted(
+        return "Error at [%d, %d]:\n\t%s".formatted(
             this.line, this.pos, this.message
         );
     }

--- a/milan-interpreter/src/test/java/ru/milan/interpreter/MilanVisitorTest.java
+++ b/milan-interpreter/src/test/java/ru/milan/interpreter/MilanVisitorTest.java
@@ -88,26 +88,6 @@ final class MilanVisitorTest {
     }
 
     @Test
-    void visitsIncrement() {
-        this.fillAndInjectMemoryToVisitor(10, new MilanVisitor(this.memory));
-        final Atom pre = this.visitor.visit(
-            MilanVisitorTest.parserFromSource("preincrement.mil").incrStmt()
-        );
-        MatcherAssert.assertThat(
-            "pre-incremented value from 10",
-            pre.asInteger(),
-            Matchers.equalTo(11)
-        );
-        final ProgramParser parsed =
-            MilanVisitorTest.parserFromSource("postincrement.mil");
-        MatcherAssert.assertThat(
-            "post-incremented value from 11",
-            this.visitor.visit(parsed.incrStmt()).asInteger(),
-            Matchers.equalTo(12)
-        );
-    }
-
-    @Test
     void visitsSimpleIfStatement() {
         this.injectAtomAndBaos(5);
         this.visitor.visit(

--- a/milan-interpreter/src/test/resources/not_simple_while.mil
+++ b/milan-interpreter/src/test/resources/not_simple_while.mil
@@ -1,5 +1,5 @@
 WHILE A < 5 DO
-    A++;
+    A := A + 1;
     B := A;
     WHILE B > 0 DO
         OUTPUT(A);

--- a/milan-interpreter/src/test/resources/simple_while.mil
+++ b/milan-interpreter/src/test/resources/simple_while.mil
@@ -1,4 +1,4 @@
 WHILE A < 5 DO
     OUTPUT(A);
-    A++;
+    A = A + 1;
 ENDDO


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the Milan interpreter codebase with several changes, including fixing syntax errors, changing statement behavior, and updating test resources.

### Detailed summary
- Updated `not_simple_while.mil` and `simple_while.mil` test resources to fix syntax errors and change statement behavior
- Updated `FormattedErrorMessage` to improve error message formatting
- Updated `Program.g4` to remove `readStmt` and `incrStmt` statements, add semicolons to `ifStmt` and `whileStmt`, and update expression grammar
- Updated `ErrorListener` to `MilanErrorListener` and changed `syntaxError` to throw an `InputMismatchException`
- Updated `MilanInterpreter` to use `MilanErrorListener` and added `Scanner` to handle `read` statements
- Updated `MilanVisitor` to remove `visitReadStmt` and add `visitRead`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->