### PR TITLE
To origin grammar

### DIFF
--- a/milan-interpreter/src/main/java/ru/milan/interpreter/MilanVisitor.java
+++ b/milan-interpreter/src/main/java/ru/milan/interpreter/MilanVisitor.java
@@ -1,16 +1,13 @@
 package ru.milan.interpreter;
 
+import ru.milan.interpreter.exception.InterpretationException;
+import ru.milan.interpreter.message.FormattedErrorMessage;
+
 import java.io.BufferedReader;
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.PrintStream;
 import java.util.Scanner;
-
-import org.cactoos.text.FormattedText;
-import ru.milan.interpreter.exception.InterpretationException;
-import ru.milan.interpreter.exception.WrongTypeException;
-import ru.milan.interpreter.message.FormattedErrorMessage;
 
 /**
  * It's a visitor that visits the parse tree and executes the program.


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds new imports, removes some imports, and removes unused exception imports in `MilanVisitor.java`.

### Detailed summary
- Added import for `InterpretationException`
- Added import for `FormattedErrorMessage`
- Removed import for `FormattedText`
- Removed import for `WrongTypeException`
- Removed unused imports for `InputStream`, `InputStreamReader`, `PrintStream`, and `Scanner`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->