### PR TITLE
Add unixized

### DIFF
--- a/milan-interpreter/pom.xml
+++ b/milan-interpreter/pom.xml
@@ -52,6 +52,10 @@ SOFTWARE.
       <artifactId>cactoos</artifactId>
     </dependency>
     <dependency>
+      <groupId>ru.l3r8y</groupId>
+      <artifactId>unixized</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
     </dependency>

--- a/milan-interpreter/src/test/java/ru/milan/interpreter/fake/FakeLexer.java
+++ b/milan-interpreter/src/test/java/ru/milan/interpreter/fake/FakeLexer.java
@@ -2,11 +2,17 @@ package ru.milan.interpreter.fake;
 
 import org.antlr.v4.runtime.CharStreams;
 import org.cactoos.io.ResourceOf;
+import ru.l3r8y.UnixizedOf;
 import ru.milan.interpreter.MilanLexer;
 
 public class FakeLexer extends MilanLexer {
 
     public FakeLexer(final String resource) throws Exception {
-        super(CharStreams.fromStream(new ResourceOf(resource).stream()));
+        super(CharStreams.fromString(
+            new UnixizedOf(new ResourceOf(resource))
+                .asText()
+                .asString()
+            )
+        );
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@ SOFTWARE.
     <mockito-core.version>5.2.0</mockito-core.version>
     <junit-pioneer.version>2.0.1</junit-pioneer.version>
     <picocli.version>4.7.1</picocli.version>
+    <unixized.version>1.0.0</unixized.version>
   </properties>
   <packaging>pom</packaging>
   <modules>
@@ -94,6 +95,11 @@ SOFTWARE.
         <groupId>org.projectlombok</groupId>
         <artifactId>lombok</artifactId>
         <version>${lombok.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>ru.l3r8y</groupId>
+        <artifactId>unixized</artifactId>
+        <version>${unixized.version}</version>
       </dependency>
       <dependency>
         <groupId>org.cactoos</groupId>


### PR DESCRIPTION
closes #52 
<!-- start pr-codex -->

## PR-Codex overview
This PR adds the `unixized` dependency to the project and uses it to read resources in `FakeLexer` class. 

### Detailed summary
- Added `unixized` dependency to the project's `pom.xml`
- Replaced `CharStreams.fromStream` with `CharStreams.fromString` in `FakeLexer` class
- Used `UnixizedOf` to read resources in `FakeLexer` class

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->